### PR TITLE
java options fix

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -99,8 +99,8 @@ services:
   fuseki:
     image: secoresearch/fuseki:4.9.0
     environment:
-      - "JAVA_OPTIONS=${FUSEKI_JAVA_OPTS}"
-      - "ADMIN_PASSWORD=${CKANINI__CKANEXT__FUSEKI__PASSWORD}"
+      - JDK_JAVA_OPTIONS=${FUSEKI_JAVA_OPTS}
+      - ADMIN_PASSWORD=${CKANINI__CKANEXT__FUSEKI__PASSWORD}
       - ENABLE_DATA_WRITE=true
       - ENABLE_UPDATE=true
       - ENABLE_UPLOAD=true


### PR DESCRIPTION
## Summary

- Replace `JAVA_OPTIONS` with `JDK_JAVA_OPTIONS` in the Fuseki service environment in `compose.yaml`
- `JAVA_OPTIONS` is not recognised by the JVM since JDK 9; `JDK_JAVA_OPTIONS` is the correct variable for modern JDK images
- Also removes unnecessary quotes around the env var values
